### PR TITLE
Improve handling duplicate book titles

### DIFF
--- a/src/main/lib/apple-notes.ts
+++ b/src/main/lib/apple-notes.ts
@@ -85,9 +85,13 @@ export class AppleNotesExtractor {
 
     console.log("MAIN: Getting note folder...");
     this.folder = (
-      await this.database
-        .all`SELECT Z_PK as z_pk, ZTITLE2 as ztitle2 FROM ziccloudsyncingobject WHERE z_ent = ${this.keys.ICFolder} AND ztitle2 = ${folder}`
-    )[0];
+      await this.database.all`
+        SELECT Z_PK as z_pk, ZTITLE2 as ztitle2 
+        FROM ziccloudsyncingobject 
+        WHERE z_ent = ${this.keys.ICFolder} 
+        AND ztitle2 = ${folder} 
+        AND zmarkedfordeletion = 0
+      `)[0]; // zmarkedfordeletion = 0 is to exclude deleted folders
     console.log("MAIN: Folder: ", this.folder);
     await this.resolveAccount(noteAccount[0].z_pk);
 

--- a/src/main/lib/apple-notes.ts
+++ b/src/main/lib/apple-notes.ts
@@ -208,7 +208,7 @@ export class AppleNotesExtractor {
       SELECT ZNAME as zname, ZIDENTIFIER as zidentifier FROM ziccloudsyncingobject
       WHERE z_ent = ${this.keys.ICAccount} AND zname = ${name}
     `;
-    console.log("Account: ", account);
+    console.log("Account: ", account ? account.zname : "Non-iCloud Account");
     return true ? account !== undefined : false;
   }
 

--- a/src/main/lib/apple-notes.ts
+++ b/src/main/lib/apple-notes.ts
@@ -130,24 +130,24 @@ export class AppleNotesExtractor {
     }
   }
 
-  async extractNoteHTML(name: string): Promise<string | void> {
+  async extractNoteHTML(note_pk: string): Promise<string | void> {
     if (!this.database) {
       console.error("MAIN: Database not found...");
       return;
     }
-    console.log("MAIN: Extracting note: ", name);
+    console.log("MAIN: Note Primary Key: ", note_pk);
 
     const notes = await this.database.get`
     SELECT
           Z_PK as z_pk, ZFOLDER as zfolder, ZTITLE1 as ztitle1 FROM ziccloudsyncingobject
         WHERE
           z_ent = ${this.keys.ICNote}
-          AND ztitle1 = ${name}
+          AND z_pk = ${note_pk}
           AND ztitle1 IS NOT NULL
           AND zfolder = ${this.folder.z_pk}
           AND zfolder NOT IN (1)
     `;
-    console.log("MAIN: Notes: ", notes);
+    console.log("MAIN: Extracting note: ", notes);
 
     // decode the protobuf
     const html = await this.resolveNote(notes.z_pk);

--- a/src/main/lib/index.ts
+++ b/src/main/lib/index.ts
@@ -71,8 +71,14 @@ export async function getUserAuthToken(uuid: string, attempt = 0): Promise<strin
 
 export class ReadwiseSync {
   mainWindow: BrowserWindow
+
   store: any // TODO: type this
   database: any
+
+  bookIdsMap = {}
+
+  booksToRefresh: Array<string> = []
+  failedBooks: Array<string> = []
 
   constructor(mainWindow: BrowserWindow, store: any) {
     this.mainWindow = mainWindow
@@ -87,7 +93,7 @@ export class ReadwiseSync {
     }
   }
 
-  async writeZipEntryToAppleNotes(entry, bookIdsMap, notesFolder, isICAccount, account) {
+  async writeZipEntryToAppleNotes(entry, notesFolder, isICAccount, account) {
     // TODO: fix apple notes filename... it's not the same as the original filename
       // Found entry: .md
       // Extracting entry: 46,109,100
@@ -102,9 +108,6 @@ export class ReadwiseSync {
       console.log(`Original name: ${originalName}`)
       console.log(`Book ID: ${bookId}`)
 
-      // track the book
-      bookIdsMap[originalName] = bookIdsMap
-
       try {
         if (entry.getData) {
           // Read the contents of the file
@@ -113,10 +116,14 @@ export class ReadwiseSync {
           // convert the markdown to html
           const contentToSave = md.render(content)
 
-          let result = false
+          let result = ""
           // check if the note already exists
-          if (await checkIfNoteExist(originalName, notesFolder, account)) {
-            console.log('Note already exists, updating note with new content')
+          const note_id = this.bookIdsMap[bookId]
+
+          console.log(`Checking if note exists: (${bookId}) - (${note_id})`)
+
+          if (await checkIfNoteExist(note_id, notesFolder, account)) {
+            console.log(`MAIN: Note already exists, updating note: ${originalName} - (${bookId})`)
 
             if (isICAccount) {
               // get the note from the apple notes database
@@ -124,6 +131,14 @@ export class ReadwiseSync {
                 originalName,
                 notesFolder
               )
+
+              // if for some reason we can't extract the existing note content, add the book to the failed list
+              if (existingHTMLContent === null) {
+                // this book failed to sync, add it to the failed list
+                console.log(`MAIN: failed to extract existing note content for ${originalName} - (${bookId})`)
+                this.failedBooks.push(bookId)
+                return;
+              }
 
               const updatedContent =
                 existingHTMLContent +
@@ -143,39 +158,38 @@ export class ReadwiseSync {
             }
           } else {
             // create a new note
-            console.log("Note doesn't exist, creating new note")
+            console.log(`MAIN: Note does not exist, creating note: ${originalName} - (${bookId})`)
             result = await createNewNote(contentToSave, originalName, notesFolder, account)
           }
 
           // track the result of the note creation
           // if it fails, add the book id to the failed list
           if (result) {
-            console.log('MAIN: note created successfully')
+            console.log(`MAIN: successfully created note: ${originalName} - (${bookId})`);
+            this.bookIdsMap[bookId] = result // track the note id for future updates
             this.mainWindow.webContents.send('syncing-progress')
           } else {
-            console.log('MAIN: failed to create note')
-            const failedBooks = store.get('failedBooks')
-            const deduplicatedFailedBooks = new Set([...failedBooks, bookId])
-            store.set('failedBooks', Array.from(deduplicatedFailedBooks))
+            console.log(`MAIN: failed to create note: ${originalName} - (${bookId})`)
+            this.failedBooks.push(bookId)
+            return;
           }
         } else {
           console.log('MAIN: entry has no data')
           if (bookId) {
-            const failedBooks = store.get('failedBooks')
-            const deduplicatedFailedBooks = new Set([...failedBooks, bookId])
-            store.set('failedBooks', Array.from(deduplicatedFailedBooks))
+            this.failedBooks.push(bookId)
+            return;
           }
         }
       } catch (e) {
         console.log('MAIN: error reading file: ', e)
         if (bookId) {
-          const failedBooks = store.get('failedBooks')
-          const deduplicatedFailedBooks = new Set([...failedBooks, bookId])
-          store.set('failedBooks', Array.from(deduplicatedFailedBooks))
+          this.failedBooks.push(bookId)
+          return;
         }
       }
       await this.removeBooksFromRefresh([bookId])
       await this.removeBookFromFailedBooks([bookId])
+
   }
 
   // https://github.com/readwiseio/obsidian-readwise/blob/56d903b8d1bc18a7816603c300c6b0afa1241d0e/src/main.ts#L285
@@ -242,7 +256,8 @@ export class ReadwiseSync {
       return
     }
 
-    const bookIdsMap = this.store.get('booksIDsMap')
+    this.bookIdsMap = this.store.get('booksIDsMap') || {}
+    this.failedBooks = this.store.get('failedBooks') || []
 
     if (entries.length) {
       // Output entry names
@@ -251,7 +266,7 @@ export class ReadwiseSync {
       const running: Promise<void>[] = [];
 
       for (const entry of entries) {
-        const p = this.writeZipEntryToAppleNotes(entry, bookIdsMap, notesFolder, isICAccount, account);
+        const p = this.writeZipEntryToAppleNotes(entry, notesFolder, isICAccount, account);
         running.push(p);
 
         // when p finishes, remove it from the array
@@ -274,6 +289,11 @@ export class ReadwiseSync {
     // Close the database
     this.database.close()
 
+    // Update the store with the latest bookIdsMap, failedBooks, booksToRefresh
+    this.store.set('booksIDsMap', this.bookIdsMap)
+    this.store.set('failedBooks', this.failedBooks)
+    this.store.set('booksToRefresh', this.booksToRefresh)
+
     // Acknowledge that the sync is completed
     await this.acknowledgeSyncCompleted()
     await this.handleSyncSuccess('Synced', exportID)
@@ -294,22 +314,20 @@ export class ReadwiseSync {
 
     console.log(`MAIN: removing books ids ${bookIds.join(', ')} from refresh list`)
 
-    const booksToRefresh = this.store.get('booksToRefresh')
-    const deduplicatedBooksToRefresh = booksToRefresh.filter(
+    const deduplicatedBooksToRefresh = this.booksToRefresh.filter(
       (bookId: string) => !bookIds.includes(bookId)
     )
-    this.store.set('booksToRefresh', deduplicatedBooksToRefresh)
+    this.booksToRefresh = deduplicatedBooksToRefresh
   }
 
   async removeBookFromFailedBooks(bookIds: Array<string>) {
     if (!bookIds.length) return
 
     console.log(`MAIN: removing books ids ${bookIds.join(', ')} from failed list`)
-    const failedBooks = this.store.get('failedBooks')
-    const deduplicatedFailedBooks = failedBooks.filter(
+    const deduplicatedFailedBooks = this.failedBooks.filter(
       (bookId: string) => !bookIds.includes(bookId)
     )
-    this.store.set('failedBooks', deduplicatedFailedBooks)
+    this.failedBooks = deduplicatedFailedBooks
   }
 
   async acknowledgeSyncCompleted() {

--- a/src/main/lib/index.ts
+++ b/src/main/lib/index.ts
@@ -118,7 +118,7 @@ export class ReadwiseSync {
 
           let result = ""
           // check if the note already exists
-          const note_id = this.bookIdsMap[bookId] || ""
+          const note_id = this.bookIdsMap[bookId]
 
           console.log(`Checking if note exists: (${bookId}) - (${note_id})`)
 
@@ -129,7 +129,13 @@ export class ReadwiseSync {
               // the primary key can be found at the end of the id return from AppleScript
               // Ex. x-coredata://E5AB9D06-5845-4AC6-A4A4-DBB2EC160D74/ICNote/p235619
               // The primary key is 235619
-              const note_pk = note_id.split('p')[1]
+              const note_pk = note_id.match(/p(\d+)$/)[1];
+
+              if (!note_pk) {
+                console.log('MAIN: failed to extract note primary key')
+                this.failedBooks.push(bookId)
+                return;
+              }
 
               // get the note's body from the apple notes database
               const existingHTMLContent = await this.database.extractNoteHTML(

--- a/src/main/lib/utils.ts
+++ b/src/main/lib/utils.ts
@@ -6,17 +6,17 @@ async function runAppleScript(
   script: string,
   { humanReadableOutput = true } = {}
 ): Promise<string> {
-  const outputArguments = humanReadableOutput ? [] : ['-ss'];
+  const outputArguments = humanReadableOutput ? [] : ['-ss']
 
   return new Promise((resolve, reject) => {
     execFile('osascript', ['-e', script, ...outputArguments], (error, stdout, stderr) => {
       if (error) {
-        reject(new Error(`Error: ${stderr || error.message}`));
+        reject(new Error(`Error: ${stderr || error.message}`))
       } else {
-        resolve(stdout.trim());
+        resolve(stdout.trim())
       }
-    });
-  });
+    })
+  })
 }
 
 export async function updateAppleNotesAccounts() {
@@ -211,28 +211,33 @@ export const checkIfFolderIsEmtpy = async (folder: string, account: string): Pro
 
 export const updateExistingNote = async (
   content: string,
-  title: string,
+  note_id: string,
   folder: string,
   account: string
 ): Promise<string> => {
   const cleanContent = sanitizeHTML(content) // Sanitize the content for AppleScript
   const script = `
       tell application "Notes"
-        set noteCreated to false
         try
-            set theAccount to account "${account}" -- specify your account name here
-            set theFolder to folder "${folder}" of theAccount -- specify your folder name here
-            set theNote to the first note in theFolder whose name is "${title}"
-            set currentContent to the body of theNote -- retrieve existing content
+            -- Specify the account and folder
+            set targetAccount to first account whose name is "${account}"
+            set targetFolder to first folder of targetAccount whose name is "${folder}"
+            
+            -- Find the note with the specified ID
+            set noteMatch to first note of targetFolder whose id is "${note_id}"
+            set noteTitle to name of noteMatch
+            set currentContent to the body of noteMatch -- retrieve existing content
+            
+            -- Update the note with the new content appended
             set newContent to currentContent & "<div><br></div>" & "${cleanContent}" -- modify appended text here
-            set body of theNote to newContent
-            log "Note '" & "${title}" & "' updated in folder '" & theFolder & "' of " & account & " theAccount."
-            set noteCreated to id of theNote
+            set body of noteMatch to newContent
+            
+            -- Return the ID of the updated note
+            return id of noteMatch
         on error
-            log "Note '" & "${title}" & "' not found in folder '" & theFolder & "' of " & account & " theAccount."
-            set noteCreated to ""
+            -- Return an empty string if the note is not found
+            return ""
         end try
-        return noteCreated
     end tell
     `
   const result = await executeAppleScript(script)
@@ -241,28 +246,32 @@ export const updateExistingNote = async (
 
 export const appendToExistingNote = async (
   content: string,
-  title: string,
+  note_id: string,
   folder: string,
   account: string
 ): Promise<string> => {
   const cleanContent = sanitizeHTML(content) // Sanitize the content for AppleScript
   const script = `
       tell application "Notes"
-        set noteCreated to false
         try
-            set theAccount to account "${account}" -- specify your account name here
-            set theFolder to folder "${folder}" of theAccount -- specify your folder name here
-            set targetNote to the first note in theFolder whose name is "${title}"
-            set noteTitle to name of targetNote
-            set body of targetNote to noteTitle & "<div><br></div>" & "${cleanContent}"
-            log "Note '" & "${title}" & "' updated in folder '" & theFolder & "' of " & account & " theAccount."
-            set noteCreated to id of targetNote
+          -- Specify the account and folder
+          set targetAccount to first account whose name is "${account}"
+          set targetFolder to first folder of targetAccount whose name is "${folder}"
+          
+          -- Find the note with the specified ID
+          set noteMatch to first note of targetFolder whose id is "${note_id}"
+          set noteTitle to name of noteMatch
+          
+          -- Append the new content to the existing note
+          set body of noteMatch to noteTitle & "<div><br></div>" & "${cleanContent}"
+
+          -- Return the ID of the updated note
+          return id of noteMatch
         on error
-            log "Note '" & "${title}" & "' not found in folder '" & theFolder & "' of " & account & " theAccount."
-            set noteCreated to ""
+          -- Return an empty string if the note is not found
+          return ""
         end try
-        return noteCreated
-    end tell
+      end tell
     `
   const result = await executeAppleScript(script)
   return result

--- a/src/main/lib/utils.ts
+++ b/src/main/lib/utils.ts
@@ -74,7 +74,7 @@ async function fetchDefaultAccount() {
 }
 
 export async function checkIfNoteExist(
-  title: string,
+  note_id: string,
   folder: string,
   account: string
 ): Promise<boolean> {
@@ -84,7 +84,7 @@ export async function checkIfNoteExist(
         try
             set theAccount to account "${account}" -- specify your account name here
             set theFolder to folder "${folder}" of theAccount -- specify your folder name here
-            set theNote to the first note in theFolder whose name is "${title}"
+            set theNote to the first note in theFolder whose id is "${note_id}"
             set noteExist to true
         on error
             set noteExist to false
@@ -214,7 +214,7 @@ export const updateExistingNote = async (
   title: string,
   folder: string,
   account: string
-): Promise<boolean> => {
+): Promise<string> => {
   const cleanContent = sanitizeHTML(content) // Sanitize the content for AppleScript
   const script = `
       tell application "Notes"
@@ -226,17 +226,17 @@ export const updateExistingNote = async (
             set currentContent to the body of theNote -- retrieve existing content
             set newContent to currentContent & "<div><br></div>" & "${cleanContent}" -- modify appended text here
             set body of theNote to newContent
-            log "Note '" & "${title}" & "' updated in folder '" & folder & "' of " & account & " account."
-            set noteCreated to true
+            log "Note '" & "${title}" & "' updated in folder '" & theFolder & "' of " & account & " theAccount."
+            set noteCreated to id of theNote
         on error
-            log "Note '" & "${title}" & "' not found in folder '" & folder & "' of " & account & " account."
-            set noteCreated to false
+            log "Note '" & "${title}" & "' not found in folder '" & theFolder & "' of " & account & " theAccount."
+            set noteCreated to ""
         end try
         return noteCreated
     end tell
     `
   const result = await executeAppleScript(script)
-  return result === 'true'
+  return result
 }
 
 export const appendToExistingNote = async (
@@ -244,7 +244,7 @@ export const appendToExistingNote = async (
   title: string,
   folder: string,
   account: string
-): Promise<boolean> => {
+): Promise<string> => {
   const cleanContent = sanitizeHTML(content) // Sanitize the content for AppleScript
   const script = `
       tell application "Notes"
@@ -255,17 +255,17 @@ export const appendToExistingNote = async (
             set targetNote to the first note in theFolder whose name is "${title}"
             set noteTitle to name of targetNote
             set body of targetNote to noteTitle & "<div><br></div>" & "${cleanContent}"
-            log "Note '" & "${title}" & "' updated in folder '" & folder & "' of " & account & " account."
-            set noteCreated to true
+            log "Note '" & "${title}" & "' updated in folder '" & theFolder & "' of " & account & " theAccount."
+            set noteCreated to id of targetNote
         on error
-            log "Note '" & "${title}" & "' not found in folder '" & folder & "' of " & account & " account."
-            set noteCreated to false
+            log "Note '" & "${title}" & "' not found in folder '" & theFolder & "' of " & account & " theAccount."
+            set noteCreated to ""
         end try
         return noteCreated
     end tell
     `
   const result = await executeAppleScript(script)
-  return result === 'true'
+  return result
 }
 
 export const createNewNote = async (
@@ -283,20 +283,19 @@ export const createNewNote = async (
         set noteTitle to "${title}" -- Use JavaScript string here
         set noteBody to "${cleanContent}" -- Use JavaScript string here
 
-        set NoteCreated to false
+        set noteCreated to ""
 
         -- Create a new note in the specified folder of the desired account
         try            
             set newNote to make new note at folder folderName of account desiredAccountName with properties {name:noteTitle, body:noteBody}
-            log "Note '" & noteTitle & "' updated in folder '" & folder & "' of " & account & " account."
-            set noteCreated to true
+            log "Note '" & noteTitle & "' updated in folder '" & folderName & "' of " & account & " desiredAccountName."
+            set noteCreated to id of newNote
         on error
-            log "Note '" & noteTitle & "' not found in folder '" & folder & "' of " & account & " account."
-            set noteCreated to false
+            log "Note '" & noteTitle & "' not found in folder '" & folderName & "' of " & account & " desiredAccountName."
         end try
         return noteCreated
     end tell
     `
   const result = await executeAppleScript(appleScript)
-  return result === 'true'
+  return result
 }


### PR DESCRIPTION
Changed how we identify and track note creation. Instead of returning `true` we return the `id` and map it to the `bookId` to keep track of the note in Apple Notes. This should handle duplicate titles and create a note for each `bookId`.

Also, fixed `failedBooks` and `booksToRefresh` values not being populated during note creation failure.

Ref #15 