### PR TITLE
Fix auto sync issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apple-notes-readwise",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apple-notes-readwise",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-notes-readwise",
   "productName": "Readwise to Apple Notes",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Export Readwise highlights to Apple Notes",
   "main": ".vite/build/index.js",
   "repository": {

--- a/src/main/lib/sync.ts
+++ b/src/main/lib/sync.ts
@@ -655,7 +655,7 @@ export class ReadwiseSync {
 
     if (!targetBookIds.length) {
       console.log('MAIN: no targetBookIds, checking for new highlights')
-      await this.queueExport(undefined, auto)
+      await this.queueExport()
       return
     }
 

--- a/src/main/lib/sync.ts
+++ b/src/main/lib/sync.ts
@@ -24,6 +24,8 @@ import {
   updateExistingNote
 } from './utils'
 
+const TAGS_TO_REPLACE_REGEX = /<\/p>|<\/h[1-6]>|<\/ul>|<\/ol>/g;
+
 const md = new MarkdownIt({
   breaks: true, // Convert '\n' in paragraphs into <br>
   html: true, // Enable HTML tags in source
@@ -143,9 +145,9 @@ export class ReadwiseSync {
         let contentToSaveHTML = md.render(content)
 
         // DEBUG: write the html file to the output folder
-        //fs.writeFileSync(`output/${originalName}.html`, contentToSaveHTML)
+        // fs.writeFileSync(`output/${originalName}.html`, contentToSaveHTML)
         // add a line break after each paragraph and heading tags for coesmetic purposes
-        contentToSaveHTML = contentToSaveHTML.replace(/<\/p>|<\/h[1-6]>|<\/ul>/g, '$&<br>');
+        contentToSaveHTML = contentToSaveHTML.replace(TAGS_TO_REPLACE_REGEX, '$&<br>');
 
         // DEBUG: write the html file to the output folder
         // fs.writeFileSync(`output/${originalName}-add-breaks.html`, contentToSaveHTML)
@@ -199,7 +201,7 @@ export class ReadwiseSync {
             // fs.writeFileSync(`output/${originalName}-updated.html`, udpatedContentHTML)
 
             // add a line break after each paragraph and heading tags for coesmetic purposes
-            udpatedContentHTML = udpatedContentHTML.replace(/<\/p>|<\/h[1-6]>|<\/ul>/g, '$&<br>');
+            udpatedContentHTML = udpatedContentHTML.replace(TAGS_TO_REPLACE_REGEX, '$&<br>');
 
             // DEBUG: write the updated html to the output folder
             // fs.writeFileSync(`output/${originalName}-updated-add-breaks.html`, udpatedContentHTML)


### PR DESCRIPTION
## Fixed
- Fix issue introduced in PR #27 that prevented auto syncing and updating notes with new highlights.
- `setInterval` not being cleared causing multiple running syncs
- Fix error caused from backend (`main.ts` and `sync.ts`) sending messages to the frontend (using `mainWindow.webContent.send()`) when the `BroswerWindow` was closed.

## Changed
- REGEX to add a `<br> tag to the end of `</ol>` tags, moved to a constant `TAGS_TO_REPLACE_REGEX`

## Added
- `syncInterval` to `main.ts`
- new method `sendToRenderer` in `ReadwiseSync` class to check if `BrowserWindow` is present before sending messages to the front-end
- Added conditional checks if `(!mainWindow.isDestroyed()` in `main.ts` to prevent sending messages to frontend when closed.