### PR TITLE
Fix dialog box rendering multiple times

### DIFF
--- a/src/renderer/components/PermissionPage.tsx
+++ b/src/renderer/components/PermissionPage.tsx
@@ -1,17 +1,23 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Card, CardContent } from './ui/card'
 // @ts-ignore
 import permissionImg from '../../images/permissions.png'
 
 export default function PermissionPage({ onIsPermissioned }) {
+  const [isRequesting, setIsRequesting] = useState(false)
+
   useEffect(() => {
+    if (isRequesting) return
+
     const getPermission = async () => {
+      setIsRequesting(true)
       const permissioned = await window.api.requestAppleNotesPermission()
       onIsPermissioned(permissioned)
+      setIsRequesting(false)
     }
 
     getPermission()
-  }, [onIsPermissioned])
+  }, [isRequesting, onIsPermissioned])
 
   return (
     <Card>


### PR DESCRIPTION
The dialog box when asking the user for permission to access the Apple Notes folder was rendering multiple times on the screen. This fix ensures it only happens once and even if the user hit 'cancel' to re-prompt them for access