### PR TITLE
Fix comment for lastSyncFailed flag

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -38,7 +38,7 @@ export interface ReadwisePluginSettings {
   /** Automatically sync on load */
   triggerOnLoad: boolean;
 
-  /** Last successful sync status ID */
+  /** Whether the last sync failed */
   lastSyncFailed: boolean;
 
   /** Last successful sync status ID */


### PR DESCRIPTION
## Summary
- clarify documentation for `lastSyncFailed`

## Testing
- `npm run lint` *(fails: couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_684062d193848323baaa5c22075ff63b